### PR TITLE
Support for SIGV4-only AWS regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ So inside your `project.clj` do:
 `:aws {
         :access-key ~(System/getenv "AWS_ACCESS_KEY")
         :secret-key ~(System/getenv "AWS_SECRET_KEY")
+        :endpoint "REGION-SPECIFIC ENDPOINT"
         :s3-static-deploy {:bucket "THE BUCKET YOU WANT TO DEPLOY TO"
                            :local-root "LOCAL DIRECTORY YOU WANT TO DEPLOY FROM"}}`
+
+The `:endpoint` keyword is only required if you want to connect to
+a region-specific endpoint (see [list of regions and
+endpoints](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)).
+This may be necessary for buckets in regions that only support AWS Signature
+Version 4.
 
 ## Deploy
 

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-aws-s3 "0.3.7"]
+                 [clj-aws-s3 "0.3.10" :exclusions [joda-time]]
+                 [joda-time/joda-time "2.9.2"]
                  [me.kanej/s3-sync "0.4.0"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/java.data "0.1.1"]]

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [clj-aws-s3 "0.3.7"]
                  [me.kanej/s3-sync "0.4.0"]
+                 [org.clojure/data.json "0.2.6"]
                  [org.clojure/java.data "0.1.1"]]
   :eval-in-leiningen true
   :min-lein-version "2.0.0"

--- a/src/leiningen/s3_static_deploy.clj
+++ b/src/leiningen/s3_static_deploy.clj
@@ -6,6 +6,7 @@
   (:import com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.services.s3.AmazonS3Client
            com.amazonaws.ClientConfiguration
+           com.amazonaws.SDKGlobalConfiguration
            com.amazonaws.services.s3.model.BucketWebsiteConfiguration))
 
 (defn- s3-client*
@@ -55,9 +56,11 @@
 (defn s3-static-deploy [project & args]
   "Deploy a local directory as a static website in AWS S3."
   (let [aws (:aws project)
-        credentials (select-keys aws [:access-key :secret-key])
+        credentials (select-keys aws [:access-key :secret-key :endpoint])
         {bucket :bucket local-root :local-root} (:s3-static-deploy aws)]
 
+    (when (:endpoint credentials)
+      (System/setProperty SDKGlobalConfiguration/ENABLE_S3_SIGV4_SYSTEM_PROPERTY "true"))
     (println (str "Deploying " local-root " to " bucket))
     (when-not (bucket-exists-in-account? credentials bucket)
       (s3/create-bucket credentials bucket))


### PR DESCRIPTION
Hi,
I'm using your plugin to deploy a static website to an S3 bucket in Frankfurt. I had to make a small extension, because Frankfurt is one of the newer regions that only support AWS Signature Version 4. Is this still interesting to you?

Thanks :)
